### PR TITLE
Sunec namedcurve

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 
 version = '2.0.0'
 sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
 
 repositories {
   mavenLocal()
@@ -17,6 +18,7 @@ repositories {
 }
 
 dependencies {
+  compile 'net.iharder:base64:2.3.9'
   testCompile(
     'junit:junit:4.12',
     'org.assertj:assertj-core:2.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'com.diffplug.gradle.spotless' version '1.3.3'
 }
 
-version = '1.0.0'
+version = '2.0.0'
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 repositories {
@@ -16,15 +16,7 @@ repositories {
   mavenCentral()
 }
 
-ext {
-  bouncycastleVersion = "1.45"
-}
-
 dependencies {
-  compile(
-    "org.bouncycastle:bcprov-jdk16:${bouncycastleVersion}"
-  )
-
   testCompile(
     'junit:junit:4.12',
     'org.assertj:assertj-core:2.4.1'

--- a/src/main/java/memlo/security/Algorithm.java
+++ b/src/main/java/memlo/security/Algorithm.java
@@ -2,8 +2,7 @@ package memlo.security;
 
 public enum Algorithm {
     SECRET_KEY("DESede"),
-    KEY_PAIR("ECDSA"),
-    KEY_PAIR_PROVIDER("BC"),
+    KEY_PAIR("EC"),
     KEY_PAIR_SPEC("secp256k1"),
     KEY_PAIR_SIGN("SHA256withECDSA"),
     HMAC("HmacSHA256"),

--- a/src/main/java/memlo/security/KeyPairFactory.java
+++ b/src/main/java/memlo/security/KeyPairFactory.java
@@ -1,36 +1,23 @@
 package memlo.security;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.SecureRandom;
-import java.security.Security;
 import java.security.NoSuchAlgorithmException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.NoSuchProviderException;
-
-import org.bouncycastle.jce.ECNamedCurveTable;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.jce.spec.ECParameterSpec;
+import java.security.SecureRandom;
+import java.security.spec.ECGenParameterSpec;
 
 public class KeyPairFactory {
-
-    static {
-        Security.addProvider(new BouncyCastleProvider());
-    }
 
     private KeyPairGenerator factory;
 
     public KeyPairFactory() {
         try {
-            ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec(Algorithm.KEY_PAIR_SPEC.algm);
-            this.factory = KeyPairGenerator.getInstance(Algorithm.KEY_PAIR.algm, Algorithm.KEY_PAIR_PROVIDER.algm);
+            this.factory = KeyPairGenerator.getInstance(Algorithm.KEY_PAIR.algm);
+            ECGenParameterSpec ecSpec = new ECGenParameterSpec(Algorithm.KEY_PAIR_SPEC.algm);
             this.factory.initialize(ecSpec, SecureRandom.getInstance("NativePRNGNonBlocking"));
-        } catch (NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
             throw new RuntimeException(e);
-        } catch (NoSuchProviderException e) {
-            ;
-        } catch (InvalidAlgorithmParameterException e) {
-            ;
         }
 
     }

--- a/src/main/java/memlo/security/KeyTranscoder.java
+++ b/src/main/java/memlo/security/KeyTranscoder.java
@@ -32,12 +32,16 @@ public final class KeyTranscoder {
         }
     }
 
-    private static byte[] getSpec(String encoded) {
+    public static byte[] getSpec(String encoded) {
         return Base64.getDecoder().decode(encoded);
     }
 
     public static String encodeKey(Key key) {
-        return Base64.getEncoder().encodeToString(key.getEncoded());
+        return encodeKey(key.getEncoded());
+    }
+
+    public static String encodeKey(byte[] key) {
+        return Base64.getEncoder().encodeToString(key);
     }
 
     public static SecretKey decodeSecretKey(String encodedSecret) {

--- a/src/main/java/memlo/security/KeyTranscoder.java
+++ b/src/main/java/memlo/security/KeyTranscoder.java
@@ -1,5 +1,6 @@
 package memlo.security;
 
+import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactory;
@@ -10,11 +11,12 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
 
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
+
+import net.iharder.Base64;
 
 /**
  * Encodes/Decodes keys
@@ -33,7 +35,11 @@ public final class KeyTranscoder {
     }
 
     public static byte[] getSpec(String encoded) {
-        return Base64.getDecoder().decode(encoded);
+        try {
+            return Base64.decode(encoded);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static String encodeKey(Key key) {
@@ -41,7 +47,7 @@ public final class KeyTranscoder {
     }
 
     public static String encodeKey(byte[] key) {
-        return Base64.getEncoder().encodeToString(key);
+        return Base64.encodeBytes(key);
     }
 
     public static SecretKey decodeSecretKey(String encodedSecret) {


### PR DESCRIPTION
This PR reverts the usage of BouncyCastle due tag memory requirements:
The key spec for private keys from Bouncy Castle have 591 bytes, against 64, using java EC. Also the tag we are using (Ultralight C) has only 144 bytes available.

Finally, this PR replaces the java.util.Base64, that isn't available on Android platform.