### PR TITLE
3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'com.diffplug.gradle.spotless' version '1.3.3'
 }
 
-version = '2.0.1'
+version = '3.0.0'
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,16 @@ repositories {
   mavenCentral()
 }
 
+ext {
+  bouncycastleVersion = "1.45"
+}
+
 dependencies {
-  compile 'net.iharder:base64:2.3.9'
+  compile(
+    "org.bouncycastle:bcprov-jdk16:${bouncycastleVersion}",
+    "net.iharder:base64:2.3.9"
+  )
+
   testCompile(
     'junit:junit:4.12',
     'org.assertj:assertj-core:2.4.1'

--- a/src/main/java/memlo/security/Algorithm.java
+++ b/src/main/java/memlo/security/Algorithm.java
@@ -2,7 +2,8 @@ package memlo.security;
 
 public enum Algorithm {
     SECRET_KEY("DESede"),
-    KEY_PAIR("EC"),
+    KEY_PAIR("ECDSA"),
+    KEY_PAIR_PROVIDER("BC"),
     KEY_PAIR_SPEC("secp256k1"),
     KEY_PAIR_SIGN("SHA256withECDSA"),
     HMAC("HmacSHA256"),

--- a/src/main/java/memlo/security/EncodingUtils.java
+++ b/src/main/java/memlo/security/EncodingUtils.java
@@ -1,0 +1,20 @@
+package memlo.security;
+
+import java.io.IOException;
+
+import net.iharder.Base64;
+
+public class EncodingUtils {
+
+    public static String asString(byte[] raw) {
+        return Base64.encodeBytes(raw);
+    }
+
+    public static byte[] asBytes(String encoded) {
+        try {
+            return Base64.decode(encoded);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/memlo/security/EncodingUtils.java
+++ b/src/main/java/memlo/security/EncodingUtils.java
@@ -1,6 +1,8 @@
 package memlo.security;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
 
 import net.iharder.Base64;
 
@@ -16,5 +18,21 @@ public class EncodingUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static byte[] asBytes(UUID uuid) {
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+
+        return bb.array();
+    }
+
+    public static UUID asUUID(byte[] bytes) {
+        ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+        Long high = byteBuffer.getLong();
+        Long low = byteBuffer.getLong();
+
+        return new UUID(high, low);
     }
 }

--- a/src/main/java/memlo/security/KeyPairFactory.java
+++ b/src/main/java/memlo/security/KeyPairFactory.java
@@ -1,11 +1,14 @@
 package memlo.security;
 
-import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.spec.ECGenParameterSpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchProviderException;
+
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECParameterSpec;
 
 public class KeyPairFactory {
 
@@ -13,10 +16,10 @@ public class KeyPairFactory {
 
     public KeyPairFactory() {
         try {
-            this.factory = KeyPairGenerator.getInstance(Algorithm.KEY_PAIR.algm);
-            ECGenParameterSpec ecSpec = new ECGenParameterSpec(Algorithm.KEY_PAIR_SPEC.algm);
+            ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec(Algorithm.KEY_PAIR_SPEC.algm);
+            this.factory = KeyPairGenerator.getInstance(Algorithm.KEY_PAIR.algm, Algorithm.KEY_PAIR_PROVIDER.algm);
             this.factory.initialize(ecSpec, SecureRandom.getInstance("NativePRNGNonBlocking"));
-        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidAlgorithmParameterException e) {
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/memlo/security/KeyTranscoder.java
+++ b/src/main/java/memlo/security/KeyTranscoder.java
@@ -1,6 +1,8 @@
 package memlo.security;
 
-import java.io.IOException;
+import static memlo.security.EncodingUtils.asBytes;
+import static memlo.security.EncodingUtils.asString;
+
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactory;
@@ -15,8 +17,6 @@ import java.security.spec.X509EncodedKeySpec;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
-
-import net.iharder.Base64;
 
 /**
  * Encodes/Decodes keys
@@ -35,19 +35,11 @@ public final class KeyTranscoder {
     }
 
     public static byte[] getSpec(String encoded) {
-        try {
-            return Base64.decode(encoded);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return asBytes(encoded);
     }
 
     public static String encodeKey(Key key) {
-        return encodeKey(key.getEncoded());
-    }
-
-    public static String encodeKey(byte[] key) {
-        return Base64.encodeBytes(key);
+        return asString(key.getEncoded());
     }
 
     public static SecretKey decodeSecretKey(String encodedSecret) {

--- a/src/main/java/memlo/security/Signer.java
+++ b/src/main/java/memlo/security/Signer.java
@@ -1,5 +1,8 @@
 package memlo.security;
 
+import static memlo.security.EncodingUtils.asBytes;
+import static memlo.security.EncodingUtils.asString;
+
 import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -9,8 +12,6 @@ import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
 import java.security.SignatureException;
-import java.io.IOException;
-import net.iharder.Base64;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -43,7 +44,7 @@ public class Signer {
                 signer.update(d.getBytes(UTF_8));
             }
             byte[] signature = signer.sign();
-            return Base64.encodeBytes(signature);
+            return asString(signature);
 
         } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
             throw new RuntimeException(e);
@@ -57,11 +58,11 @@ public class Signer {
             for (String d: data) {
                 signer.update(d.getBytes(UTF_8));
             }
-            byte[] rawSignature = Base64.decode(signature);
+            byte[] rawSignature = asBytes(signature);
             return signer.verify(rawSignature);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
-        } catch (InvalidKeyException | SignatureException | IOException e) {
+        } catch (InvalidKeyException | SignatureException e) {
             return false;
         }
     }
@@ -75,7 +76,7 @@ public class Signer {
                 generator.update(d.getBytes(UTF_8));
             }
             byte[] hmac = generator.doFinal();
-            return Base64.encodeBytes(hmac);
+            return asString(hmac);
 
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw new RuntimeException(e);
@@ -85,7 +86,7 @@ public class Signer {
     public String digest(String... data) {
         byte[] bytes = this.digestRaw(data);
 
-        return Base64.encodeBytes(bytes);
+        return asString(bytes);
     }
 
     public byte[] digestRaw(String... data) {

--- a/src/main/java/memlo/security/Signer.java
+++ b/src/main/java/memlo/security/Signer.java
@@ -6,6 +6,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.Security;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.io.IOException;
@@ -13,6 +14,8 @@ import net.iharder.Base64;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public class Signer {
 
@@ -22,6 +25,10 @@ public class Signer {
 
     private Signer() {
 
+    }
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
     }
 
     public static Signer getInstance() {

--- a/src/main/java/memlo/security/Signer.java
+++ b/src/main/java/memlo/security/Signer.java
@@ -85,12 +85,7 @@ public class Signer {
     public String digest(String... data) {
         byte[] bytes = this.digestRaw(data);
 
-        StringBuilder sb = new StringBuilder();
-        for (byte b: bytes) {
-            sb.append(String.format("%02X", b));
-        }
-
-        return sb.toString();
+        return Base64.encodeBytes(bytes);
     }
 
     public byte[] digestRaw(String... data) {

--- a/src/test/java/memlo/security/EncodingUtilsTest.java
+++ b/src/test/java/memlo/security/EncodingUtilsTest.java
@@ -1,0 +1,29 @@
+package memlo.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+public class EncodingUtilsTest {
+
+    @Test
+    public void encodingUUIdAsBytes_byteArraySizeRight() {
+        UUID uuid = UUID.randomUUID();
+
+        byte[] result = EncodingUtils.asBytes(uuid);
+
+        assertThat(result.length).isEqualTo(16);
+    }
+
+    @Test
+    public void asBytesAsUUID_generatesSameUUID() {
+        UUID uuid = UUID.randomUUID();
+
+        byte[] bytes = EncodingUtils.asBytes(uuid);
+        UUID reconstructedUuid = EncodingUtils.asUUID(bytes);
+
+        assertThat(reconstructedUuid).isEqualTo(uuid);
+    }
+}


### PR DESCRIPTION
Voltando pro bouncycastle já que não vamos mais escrever a assinatura na tag.
Espero que essa mudança faça com que apliação rode no android 6.0, mas de qualquer forma não vejo um bom motivo para não fazê-la.
Além disso, adicionando alguns métodos utilitários para tratar com conversão de string/bytes/uuids de forma uniforme no wakko/yakko.